### PR TITLE
Include option to disable checking for spaces or tabs

### DIFF
--- a/highlight_whitespaces.py
+++ b/highlight_whitespaces.py
@@ -58,7 +58,6 @@ def highlight_whitespaces(view):
     tab_scope_name = hws_settings.get('highlight_whitespaces_tab_highlight_scope_name',
                                        DEFAULT_COLOR_SCOPE_NAME)
     if view.size() <= max_size and not is_find_results(view):
-        print "check spaces? %s" % hws_settings.get('highlight_whitespaces_check_spaces', DEFAULT_CHECK_SPACES)
         if hws_settings.get('highlight_whitespaces_check_spaces', DEFAULT_CHECK_SPACES):
             space_regions = find_whitespaces_spaces(view)
             view.add_regions('WhitespacesHighlightListener',

--- a/highlight_whitespaces.sublime-settings
+++ b/highlight_whitespaces.sublime-settings
@@ -4,7 +4,6 @@
 
   // Tabs color is determined by scope (default, "invalid")
 //  "highlight_whitespaces_tab_highlight_scope_name": "Whitespaces.tab.highlight",
-  "debug": true,
   // Max file size to search
   "highlight_whitespaces_file_max_size": 1048576,
 


### PR DESCRIPTION
I added options for disabling of highlighting of spaces or tabs.

I am working on a legacy codebase that mixes tabs and spaces, but we would like our code styles to be spaces-only.  So I'm using this to only highlight tabs, where they occur.

I've left the defaults to be checking for both.
